### PR TITLE
Add support for JPEG masks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 project.xcworkspace
 xcuserdata
+.DS_Store

--- a/Examples/Mac/JPNGTest.xcodeproj/project.pbxproj
+++ b/Examples/Mac/JPNGTest.xcodeproj/project.pbxproj
@@ -368,10 +368,14 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JPNGTest/JPNGTest-Prefix.pch";
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				INFOPLIST_FILE = "JPNGTest/JPNGTest-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wno-objc-missing-property-synthesis",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -383,10 +387,14 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JPNGTest/JPNGTest-Prefix.pch";
-				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				INFOPLIST_FILE = "JPNGTest/JPNGTest-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wno-objc-missing-property-synthesis",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Examples/Mac/JPNGTest/main.m
+++ b/Examples/Mac/JPNGTest/main.m
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
-    return NSApplicationMain(argc, (const char **)argv);
+    return NSApplicationMain(argc, argv);
 }

--- a/JPNG/JPNG.h
+++ b/JPNG/JPNG.h
@@ -65,6 +65,7 @@ JPNGFooter;
 
 CGImageRef CGImageCreateWithJPNGData(NSData *data, BOOL forceDecompression);
 NSData *CGImageJPNGRepresentation(CGImageRef image, CGFloat quality);
+NSData *CGImagePNGOfAlpha( CGImageRef image);
 
 
 #if TARGET_OS_IPHONE
@@ -85,6 +86,14 @@ NSData *UIImageJPNGRepresentation(UIImage *image, CGFloat quality);
 
 NSImage *NSImageWithJPNGData(NSData *data, CGFloat scale);
 NSData *NSImageJPNGRepresentation(NSImage *image, CGFloat quality);
+
+@interface NSBitmapImageRep(PNGOfAlpha)
+
+-(NSData *)JPNGRepresentationWithQuality:(CGFloat)quality;
+-(NSData *)PNGOfAlpha;
+
+@end
+
 
 
 #endif

--- a/JPNG/JPNG.h
+++ b/JPNG/JPNG.h
@@ -1,7 +1,7 @@
 //
 //  JPNG.h
 //
-//  Version 1.2.1
+//  Version 1.3
 //
 //  Created by Nick Lockwood on 05/01/2013.
 //  Copyright 2013 Charcoal Design
@@ -63,7 +63,7 @@ JPNGFooter;
 
 //cross-platform implementation
 
-CGImageRef CGImageCreateWithJPNGData(NSData *data, BOOL forceDecompression);
+CGImageRef CGImageCreateWithJPNGData(NSData *data, CGSize targetSize,  BOOL forceDecompression);
 NSData *CGImageJPNGRepresentation(CGImageRef image, CGFloat quality);
 NSData *CGImagePNGOfAlpha( CGImageRef image);
 

--- a/JPNGTool/JPNGTool.xcodeproj/project.pbxproj
+++ b/JPNGTool/JPNGTool.xcodeproj/project.pbxproj
@@ -122,7 +122,7 @@
 		01F9E424162C62DD00877219 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Charcoal Design";
 			};
 			buildConfigurationList = 01F9E427162C62DD00877219 /* Build configuration list for PBXProject "JPNGTool" */;
@@ -165,6 +165,7 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;

--- a/JPNGTool/JPNGTool.xcodeproj/xcshareddata/xcschemes/JPNGTool.xcscheme
+++ b/JPNGTool/JPNGTool.xcodeproj/xcshareddata/xcschemes/JPNGTool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:JPNGTool.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "01F9E42C162C62DD00877219"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "01F9E42C162C62DD00877219"

--- a/JPNGTool/Source/main.m
+++ b/JPNGTool/Source/main.m
@@ -33,9 +33,11 @@
 #import <AppKit/AppKit.h>
 #import "JPNG.h"
 
+#define EXTRACT_ALPHA 1
 
 int main(int argc, const char * argv[])
 {
+    NSString *outputExtension= EXTRACT_ALPHA ? @"maskpng" : @"jpng";
     @autoreleasepool
     {
         if (argc == 1)
@@ -51,9 +53,13 @@ int main(int argc, const char * argv[])
             NSLog(@"Input file '%@' does not exist", inputFile);
             return 0;
         }
+        NSLog(@"Will convert '%@' to JPNG", inputFile);
         
         //output file
-        NSString *outputFile = [[inputFile stringByDeletingPathExtension] stringByAppendingPathExtension:@"jpng"];
+        
+        
+        
+        NSString *outputFile = [[inputFile stringByDeletingPathExtension] stringByAppendingPathExtension:outputExtension];
         if (argc > 2)
         {
             outputFile = [NSString stringWithCString:argv[2] encoding:NSUTF8StringEncoding];
@@ -81,11 +87,11 @@ int main(int argc, const char * argv[])
         }
         
         //load image
-        NSImage *image = [[NSImage alloc] initWithContentsOfFile:inputFile];        
+        NSBitmapImageRep *image = [[NSBitmapImageRep alloc] initWithData:[NSData dataWithContentsOfMappedFile:inputFile]];
         if (image)
         {
-            //save as JPNG
-            NSData *data = NSImageJPNGRepresentation(image, quality);
+            //save as JPNG or PNG of alpha
+            NSData *data = EXTRACT_ALPHA ? [image PNGOfAlpha] : [image JPNGRepresentationWithQuality:quality];
             if (!data)
             {
                 NSLog(@"Failed to convert '%@' to JPNG", inputFile);

--- a/JPNGTool/Source/main.m
+++ b/JPNGTool/Source/main.m
@@ -33,7 +33,7 @@
 #import <AppKit/AppKit.h>
 #import "JPNG.h"
 
-#define EXTRACT_ALPHA 1
+#define EXTRACT_ALPHA 0
 
 int main(int argc, const char * argv[])
 {
@@ -75,7 +75,7 @@ int main(int argc, const char * argv[])
         }
         
         //quality
-        float quality = 0.8f;
+        float quality = 0.5f;
         if (argc > 3)
         {
             quality = [[NSString stringWithCString:argv[3] encoding:NSUTF8StringEncoding] floatValue];

--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ The examples folder includes a benchmarking tool to compare PNG vs JPNG performa
 Release notes
 --------------------
 
+Version 1.3
+
+- JPNG file format version 2 uses JPEG to compress the mask
+- Reads both versions
+- Version to write can be specified
+
+
 Version 1.2.1
 
 - Eliminated white border artifacts on the sides of transparent areas when creating the JPEG data


### PR DESCRIPTION
JPEGs can be much more compact and faster to decode, so use them for the mask image as well (bumping the file format version)
